### PR TITLE
fix(security): use hash_equals for password comparison

### DIFF
--- a/server/public/share.php
+++ b/server/public/share.php
@@ -83,7 +83,7 @@ function handle_delete(): void {
 
 function check_password(string $id, string $password): bool {
     $meta = json_decode(file_get_contents(get_meta_path($id)), true);
-    if ($password != $meta["password"]) {
+    if (!hash_equals($meta["password"], $password)) {
         http_response_code(401);
         echo "Unauthorized";
         return false;


### PR DESCRIPTION
Replace loose comparison operator (!=) with hash_equals() in the check_password function to prevent timing attacks.

The previous implementation using != allowed attackers to potentially infer password characters by measuring response time differences. hash_equals() performs constant-time string comparison, eliminating this timing side-channel vulnerability.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
