### PR TITLE
feat: add Docker support for easy self-hosted deployment

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,3 @@
+data/
+*.md
+!public/*.md

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.3-apache
+
+# Enable Apache rewrite module
+RUN a2enmod rewrite
+
+# Set working directory
+WORKDIR /var/www
+
+# Copy public files
+COPY public/ /var/www/html/
+
+# Create data and quotes directories
+RUN mkdir -p /var/www/data /var/www/quotes \
+    && chown -R www-data:www-data /var/www/data /var/www/quotes
+
+# Apache configuration for .htaccess
+RUN echo '<Directory /var/www/html>\n\
+    AllowOverride All\n\
+    Require all granted\n\
+</Directory>' > /etc/apache2/conf-available/custom.conf \
+    && a2enconf custom
+
+EXPOSE 80

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./data:/var/www/data
+      - ./quotes:/var/www/quotes
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
Add Docker containerization with PHP 8.3 and Apache for running Just Share Please in a container.

## Changes
- **Dockerfile**: PHP 8.3 with Apache, rewrite module enabled
- **docker-compose.yml**: Service config with bind mount for data persistence
- **.dockerignore**: Exclude runtime data from image

## Usage
```bash
cd server && docker compose up -d
# Available at http://localhost:8080
```

The `data/` directory is mounted as a volume for persistence across container restarts.

---
This PR addresses the Docker support request from #27 (split from original PR as requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)