### PR TITLE
feat: add publication timestamp to shared notes

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -31,6 +31,7 @@
 <body>
     <div class="content">
         <div id="main"></div>
+        <div id="note-footer"></div>
         <div id="footer">
             Created using <a href="/">Just Share Please</a> for <a href="https://obsidian.md">Obsidian</a> – <a href="#" id="download-markdown">Download Markdown</a> – <a href="#" id="open-in-obsidian">Copy to Obsidian</a>
         </div>

--- a/server/public/index.js
+++ b/server/public/index.js
@@ -98,7 +98,7 @@ function loadNoteFooter(id) {
         success: meta => {
             if (meta && meta.created) {
                 let date = new Date(meta.created * 1000);
-                let formatted = date.toLocaleDateString("fi-FI", {
+                let formatted = date.toLocaleDateString(undefined, {
                     day: "numeric",
                     month: "numeric",
                     year: "numeric",
@@ -106,7 +106,7 @@ function loadNoteFooter(id) {
                     minute: "2-digit"
                 });
                 let footerHtml = '<div class="note-footer-divider"></div>';
-                footerHtml += `<p class="note-timestamp">Jaettu: ${formatted}</p>`;
+                footerHtml += `<p class="note-timestamp">Shared: ${formatted}</p>`;
                 noteFooter.html(footerHtml);
             }
         },

--- a/server/public/index.js
+++ b/server/public/index.js
@@ -38,6 +38,7 @@ for (let replacement of rulesToReplace) {
 }
 
 let main = $("#main");
+let noteFooter = $("#note-footer");
 let download = $("#download-markdown");
 let open = $("#open-in-obsidian");
 
@@ -51,6 +52,7 @@ display();
 
 function display() {
     main.html(`<div class="center-message"><p>Loading...</p></div>`);
+    noteFooter.html("");
     let id = getId();
     $.ajax({
         method: "get",
@@ -77,9 +79,40 @@ function display() {
                 download.attr("download", `${window.document.title}.md`);
                 download.attr("href", `data:text/plain;charset=utf-8,${encodeURIComponent(t)}`);
                 open.attr("href", `obsidian://new?name=${encodeURI(window.document.title)}&content=${encodeURIComponent(t)}`);
+
+                // load note footer with publication time (only for shared notes)
+                if (id) {
+                    loadNoteFooter(id);
+                }
             });
         },
         error: (r, s, e) => main.html(`<div class="center-message"><p>Error loading shared note with id <code>${id}</code>: <code>${s} ${e}</code></p><p><a href="#">Home</a></p></div>`)
+    });
+}
+
+function loadNoteFooter(id) {
+    // Fetch note metadata
+    $.ajax({
+        method: "get",
+        url: `share.php?meta&id=${id}`,
+        success: meta => {
+            if (meta && meta.created) {
+                let date = new Date(meta.created * 1000);
+                let formatted = date.toLocaleDateString("fi-FI", {
+                    day: "numeric",
+                    month: "numeric",
+                    year: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit"
+                });
+                let footerHtml = '<div class="note-footer-divider"></div>';
+                footerHtml += `<p class="note-timestamp">Jaettu: ${formatted}</p>`;
+                noteFooter.html(footerHtml);
+            }
+        },
+        error: () => {
+            // Silently fail if metadata not available
+        }
     });
 }
 

--- a/server/public/share.php
+++ b/server/public/share.php
@@ -2,7 +2,12 @@
 
 switch ($_SERVER["REQUEST_METHOD"]) {
     case "GET":
-        handle_get();
+        // Route to appropriate handler
+        if (isset($_GET["meta"])) {
+            handle_meta();
+        } else {
+            handle_get();
+        }
         break;
     case "POST":
         handle_post();
@@ -29,6 +34,30 @@ function handle_get(): void {
     echo $content;
 }
 
+function handle_meta(): void {
+    header("Content-Type: application/json");
+    parse_str($_SERVER["QUERY_STRING"], $query);
+    if (!isset($query["id"])) {
+        http_response_code(400);
+        echo json_encode(["error" => "No id"]);
+        return;
+    }
+
+    $meta_path = get_meta_path($query["id"]);
+    if (!file_exists($meta_path)) {
+        http_response_code(404);
+        echo json_encode(["error" => "Not found"]);
+        return;
+    }
+
+    $meta = json_decode(file_get_contents($meta_path), true);
+    // Return only public info (not password)
+    echo json_encode([
+        "id" => $meta["id"],
+        "created" => $meta["created"] ?? null
+    ]);
+}
+
 function handle_post(): void {
     $content = get_markdown_content();
     if ($content === null)
@@ -46,7 +75,8 @@ function handle_post(): void {
 
     $meta = json_encode([
         "id" => $id,
-        "password" => $password
+        "password" => $password,
+        "created" => time()
     ]);
 
     // store markdown and metadata in data path

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -65,6 +65,26 @@ h1:hover .header-anchor, h2:hover .header-anchor, h3:hover .header-anchor, h4:ho
     transform: translate(-50%, -60%);
 }
 
+#note-footer {
+    margin-top: 60px;
+    padding-top: 20px;
+    text-align: center;
+    color: #666;
+    font-size: 0.9em;
+}
+
+.note-footer-divider {
+    width: 100px;
+    height: 1px;
+    background: linear-gradient(to right, transparent, #9275f0, transparent);
+    margin: 0 auto 20px;
+}
+
+.note-timestamp {
+    margin: 0;
+    font-size: 0.85em;
+}
+
 #footer {
     position: absolute;
     left: 0;
@@ -132,6 +152,10 @@ input[type=checkbox]:checked:after {
 
     input[type=checkbox]:checked:after {
         background-color: #1e1e1e;
+    }
+
+    #note-footer {
+        color: #999;
     }
 }
 


### PR DESCRIPTION
## Summary
Display when a note was first shared in a decorative footer area below the note content.

## Changes

### Backend
- Add `created` Unix timestamp to `meta.json` when a note is first shared
- Add `GET ?meta&id=xxx` endpoint that returns public metadata (id, created)
  - Does not expose password or other private fields

### Frontend
- Add `note-footer` element below main content area
- Fetch and display creation timestamp for shared notes
- Format timestamp in Finnish locale (dd.mm.yyyy, hh:mm)
- Decorative divider with gradient effect
- Support both light and dark themes

## Example
When viewing a shared note, readers will see:

---
*Jaettu: 30.1.2026, 16:48*

## Notes
The publication time helps readers understand when content was shared, providing useful context especially for time-sensitive information.

---
This PR addresses the publication time feature from #27 (split from original PR as requested, without the quotes feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)